### PR TITLE
Calculate AV1 mime from codec_data

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn main() -> Result<(), Error> {
         audio_streams: vec![
             audio::AudioStream {
                 name: "audio_0".to_string(),
-                lang: "eng".to_string(),
+                lang: "en".to_string(),
                 default: true,
                 wave: "sine".to_string(),
             },

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, Mutex};
 
 use crate::State;
 
-
 pub(crate) fn probe_encoder(state: Arc<Mutex<State>>, enc: gst::Element, name: String) {
     enc.static_pad("src").unwrap().add_probe(
         gst::PadProbeType::EVENT_DOWNSTREAM,
@@ -16,8 +15,13 @@ pub(crate) fn probe_encoder(state: Arc<Mutex<State>>, enc: gst::Element, name: S
                         // https://www.reddit.com/r/AV1/comments/stbk3r/av1_in_hls_manifests_works_for_browsers_that/
                         // https://github.com/GStreamer/gst-plugins-base/blob/master/gst-libs/gst/pbutils/codec-utils.c#L2402-L2404
                         // https://aomediacodec.github.io/av1-isobmff/#codecsparam
-                        // TODO parse the codec_data from structure and set the mime accordingly
-                        mime = "av01.0.00M.08".into();
+                        if let Ok(codec_data) = structure.get::<&gst::BufferRef>("codec_data") {
+                            let map = codec_data.map_readable().unwrap();
+                            mime = calculate_av1_mime(map.as_slice()).into();
+                        } else {
+                            // Fallback to a default mime
+                            mime = "av01.0.00M.08".into();
+                        }
                     }
                     let mut state = state.lock().unwrap();
                     state.all_mimes.insert(name.to_string(), mime.into());
@@ -29,4 +33,89 @@ pub(crate) fn probe_encoder(state: Arc<Mutex<State>>, enc: gst::Element, name: S
             _ => gst::PadProbeReturn::Ok,
         },
     );
+}
+
+// Parse the AV1CodecConfigurationRecord from the codec_data buffer and calculate the mime type.
+//
+// Syntax of data is:
+// aligned(8) class AV1CodecConfigurationRecord {
+//
+//     unsigned int(1) marker = 1;
+//     unsigned int(7) version = 1;
+//
+//     unsigned int(3) seq_profile;
+//     unsigned int(5) seq_level_idx_0;
+//
+//     unsigned int(1) seq_tier_0;
+//     unsigned int(1) high_bitdepth;
+//     unsigned int(1) twelve_bit;
+//     unsigned int(1) monochrome;
+//     unsigned int(1) chroma_subsampling_x;
+//     unsigned int(1) chroma_subsampling_y;
+//     unsigned int(2) chroma_sample_position;
+//     unsigned int(3) reserved = 0;
+//     ...
+//  }
+// https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax
+//
+// The codecs parameter string for the AOM AV1 codec is as follows:
+//
+// <sample entry 4CC>.<profile>.<level><tier>.<bitDepth>
+//
+// All fields following the sample entry 4CC are expressed as double digit decimals, unless indicated
+// otherwise. Leading or trailing zeros cannot be omitted.
+//
+// The profile parameter value, represented by a single digit decimal, SHALL equal the value of
+// seq_profile in the Sequence Header OBU. The level parameter value SHALL equal the first level
+// value indicated by seq_level_idx in the Sequence Header OBU. The tier parameter value SHALL be equal
+// to M when the first seq_tier value in the Sequence Header OBU is equal to 0, and H when it is equal
+// to 1. The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in [AV1]
+// derived from the Sequence Header OBU.
+//
+// The parameters sample entry 4CC, profile, level, tier, and bitDepth are all mandatory fields.
+// https://aomediacodec.github.io/av1-isobmff/#codecsparam
+//
+// https://aomediacodec.github.io/av1-spec/av1-spec.pdf - 5.5.2. Color config syntax
+fn calculate_av1_mime(data: &[u8]) -> String {
+    assert!(data.len() >= 3);
+    let seq_profile = (data[1] >> 5) & 0b0111;
+    let seq_level_idx_0 = data[1] & 0b0001_1111;
+    let tier = {
+        let seq_tier_0 = data[2] >> 7;
+        if seq_tier_0 == 0 {
+            "M"
+        } else {
+            "H"
+        }
+    };
+    let high_bitdepth = (data[2] >> 6) & 0b0000_0001;
+    let twelve_bit = (data[2] >> 5) & 0b0000_0001;
+    let bit_depth: u8 = if seq_profile == 2 && high_bitdepth == 1 {
+        if twelve_bit == 1 {
+            12
+        } else {
+            10
+        }
+    } else if high_bitdepth == 1 {
+        10
+    } else {
+        8
+    };
+    format!(
+        "av01.{}.{:02}{}.{:02}",
+        seq_profile, seq_level_idx_0, tier, bit_depth
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_calculate_av1_mimes() {
+        assert_eq!(
+            calculate_av1_mime(&[0b1000_0001, 0b0000_0000, 0b0000_0000]),
+            "av01.0.00M.08"
+        );
+    }
 }

--- a/src/video.rs
+++ b/src/video.rs
@@ -42,7 +42,7 @@ impl VideoStream {
             .build()?;
         let Ok((enc, parser, capsfilter)) = Self::setup_codec(self) else { todo!() };
 
-        let mux = gst::ElementFactory::make("cmafmux")
+        let mux = gst::ElementFactory::make("isofmp4mux")
             .property("fragment-duration", 2000.mseconds())
             .property_from_str("header-update-mode", "update")
             .property("write-mehd", true)
@@ -121,9 +121,9 @@ impl VideoStream {
             }
             "av1" => {
                 _enc = gst::ElementFactory::make("rav1enc")
-                .property("speed-preset", 10 as u32)
+                .property("speed-preset", 10u32)
                 .property("low-latency", true)
-                .property("max-key-frame-interval", 60 as u64)
+                .property("max-key-frame-interval", 60u64)
                 .property("bitrate", self.bitrate as i32)
                 .build()?;
                 _parser = gst::ElementFactory::make("av1parse").build()?;


### PR DESCRIPTION
This works to play the stream on Firefox, Chrome, and Safari. But in Safari it doesn't play natively, didn't figure out why.

Used this player to test: http://players.akamai.com/players/hlsjs